### PR TITLE
Changed requirement of global configuration to optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ wget http://nanbando.github.io/core/nanbando.phar.pubkey
 chmod +x nanbando.phar
 mv nanbando.phar /usr/local/bin/nanbando
 mv nanbando.phar.pubkey /usr/local/bin/nanbando.pubkey
+nanbando check
 ```
 
 After first installation you can update the application with a built-in command.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1,7 +1,7 @@
 Configuration
 =============
 
-The configuration is devided into two parts - global and project configuration.
+The configuration is devided into two parts - global (optional) and project configuration.
 
 Global Configuration
 --------------------
@@ -13,7 +13,7 @@ Put this configuration into ``~/.nanbando.yml``.
 
     nanbando:
         storage:
-            local_directory: "%home%/nanbando/local"
+            local_directory: "%home%/nanbando"
             remote_service: filesystem.remote
 
     oneup_flysystem:
@@ -35,6 +35,10 @@ Put this configuration into ``~/.nanbando.yml``.
 
 For nanbando you have to define the local directory, where the backup command can place the backup archives, and the
 remote filesystem-service which can be configured in the ``oneup_flysystem`` extension.
+
+By default the ``local_directory`` will be set to ``%home%/nanbando`` and the ``remote_service`` will be ``null``. This
+leads to local backups will work out of the box but all commands (``fetch``, ``push`) which needs the remote-storage
+will be disabled.
 
 Local Configuration
 -------------------

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -3,6 +3,11 @@ Configuration
 
 The configuration is devided into two parts - global (optional) and project configuration.
 
+.. warning::
+
+    After changing configuration please run command ``reconfigure`` to be sure that the configuration will be used for
+    recreating the symfony container.
+
 Global Configuration
 --------------------
 
@@ -37,7 +42,7 @@ For nanbando you have to define the local directory, where the backup command ca
 remote filesystem-service which can be configured in the ``oneup_flysystem`` extension.
 
 By default the ``local_directory`` will be set to ``%home%/nanbando`` and the ``remote_service`` will be ``null``. This
-leads to local backups will work out of the box but all commands (``fetch``, ``push`) which needs the remote-storage
+leads to local backups will work out of the box but all commands (``fetch``, ``push``) which needs the remote-storage
 will be disabled.
 
 Local Configuration

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -20,3 +20,5 @@ After first installation you can update the application with a built-in command.
 .. note::
 
     The executable is signed with a OpenSSL private key. This ensures the origin of the build.
+
+Check the configuration state of your application by using the command ``nanbando check``.

--- a/src/Bundle/Command/CheckCommand.php
+++ b/src/Bundle/Command/CheckCommand.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Nanbando\Bundle\Command;
+
+use Nanbando\Core\Plugin\PluginRegistry;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\OptionsResolver\Exception\InvalidArgumentException;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class CheckCommand extends ContainerAwareCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('check')
+            ->setDescription('Checks configuration issues')
+            ->setHelp(
+                <<<EOT
+The <info>{$this->getName()}</info> command looks for configuration issues
+
+EOT
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $io->title('Configuration Check Report');
+
+        $io->writeln('Local directory: ' . $this->getContainer()->getParameter('nanbando.storage.local_directory'));
+
+        if (!$this->getContainer()->has('filesystem.remote')) {
+            $io->warning(
+                'No remote storage configuration found. This leads into disabled "fetch" and "push" commands.' .
+                'Please follow the documentation for global configuration.' . PHP_EOL . PHP_EOL .
+                'http://nanbando.readthedocs.io/en/latest/configuration.html#global-configuration'
+            );
+        } else {
+            $io->writeln('Remote Storage: YES');
+        }
+
+        $backups = $this->getContainer()->getParameter('nanbando.backup');
+        if (0 === count($backups)) {
+            $io->warning(
+                'No backup configuration found. Please follow the documentation for local configuration.' . PHP_EOL . PHP_EOL .
+                'http://nanbando.readthedocs.io/en/latest/configuration.html#local-configuration'
+            );
+        }
+
+        $this->checkBackups($io, $backups);
+
+        $io->writeln('');
+    }
+
+    /**
+     * Check backup-configuration.
+     *
+     * @param SymfonyStyle $io
+     * @param array $backups
+     */
+    private function checkBackups(SymfonyStyle $io, array $backups)
+    {
+        /** @var PluginRegistry $plugins */
+        $plugins = $this->getContainer()->get('plugins');
+        foreach ($backups as $name => $backup) {
+            $this->checkBackup($plugins, $io, $name, $backup);
+        }
+    }
+
+    /**
+     * Check single backup-configuration.
+     *
+     * @param PluginRegistry $plugins
+     * @param SymfonyStyle $io
+     * @param string $name
+     * @param array $backup
+     *
+     * @return bool
+     */
+    private function checkBackup(PluginRegistry $plugins, SymfonyStyle $io, $name, array $backup)
+    {
+        $io->section('Backup: ' . $name);
+        if (!$plugins->has($backup['plugin'])) {
+            $io->warning(sprintf('Plugin "%s" not found', $backup['plugin']));
+
+            return false;
+        }
+
+        $optionsResolver = new OptionsResolver();
+        $plugins->getPlugin($backup['plugin'])->configureOptionsResolver($optionsResolver);
+
+        try {
+            $optionsResolver->resolve($backup['parameter']);
+        } catch (InvalidArgumentException $e) {
+            $io->warning(sprintf('Parameter not valid' . PHP_EOL . PHP_EOL . 'Message: "%s"', $e->getMessage()));
+
+            return false;
+        }
+
+        $io->writeln('OK');
+
+        return true;
+    }
+}

--- a/src/Bundle/Command/FetchCommand.php
+++ b/src/Bundle/Command/FetchCommand.php
@@ -75,4 +75,12 @@ EOT
             $storage->fetch($file);
         }
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isEnabled()
+    {
+        return $this->getContainer()->has('filesystem.remote');
+    }
 }

--- a/src/Bundle/Command/PushCommand.php
+++ b/src/Bundle/Command/PushCommand.php
@@ -37,4 +37,12 @@ EOT
             $storage->push($file);
         }
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isEnabled()
+    {
+        return $this->getContainer()->has('filesystem.remote');
+    }
 }

--- a/src/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bundle/DependencyInjection/Configuration.php
@@ -4,6 +4,7 @@ namespace Nanbando\Bundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Webmozart\PathUtil\Path;
 
 class Configuration implements ConfigurationInterface
 {
@@ -31,8 +32,11 @@ class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
                 ->arrayNode('storage')
+                    ->addDefaultsIfNotSet()
                     ->children()
-                        ->scalarNode('local_directory')->end()
+                        ->scalarNode('local_directory')
+                            ->defaultValue(Path::join([Path::getHomeDirectory(), 'nanbando']))
+                        ->end()
                         ->scalarNode('remote_service')->end()
                     ->end()
                 ->end()

--- a/src/Bundle/DependencyInjection/NanbandoExtension.php
+++ b/src/Bundle/DependencyInjection/NanbandoExtension.php
@@ -24,7 +24,12 @@ class NanbandoExtension extends Extension
         $container->setParameter('nanbando.temp', $config['temp']);
         $container->setParameter('nanbando.backup', $config['backup']);
         $container->setParameter('nanbando.storage.local_directory', $config['storage']['local_directory']);
-        $container->setParameter('nanbando.storage.remote_service', $config['storage']['remote_service']);
+
+        if (array_key_exists('remote_service', $config['storage'])
+            && $config['storage']['remote_service'] !== 'filesystem.remote'
+        ) {
+            $container->setAlias('filesystem.remote', $config['storage']['remote_service']);
+        }
 
         $container->prependExtensionConfig(
             'oneup_flysystem',

--- a/src/Bundle/Resources/config/services.xml
+++ b/src/Bundle/Resources/config/services.xml
@@ -32,9 +32,9 @@
         <service id="storage" class="Nanbando\Core\Storage\LocalStorage">
             <argument type="string">%nanbando.name%</argument>
             <argument type="service" id="temporary_files"/>
-            <argument type="service" id="filesystem.local"/>
-            <argument type="service" id="filesystem.remote"/>
             <argument type="service" id="slugify"/>
+            <argument type="service" id="filesystem.local"/>
+            <argument type="service" id="filesystem.remote" on-invalid="null"/>
         </service>
 
         <!-- core service -->

--- a/src/Core/Flysystem/PrefixAdapter.php
+++ b/src/Core/Flysystem/PrefixAdapter.php
@@ -19,7 +19,7 @@ class PrefixAdapter implements AdapterInterface
     private $adapter;
 
     /**
-     * @param string           $root
+     * @param string $root
      * @param AdapterInterface $adapter
      */
     public function __construct($root, AdapterInterface $adapter)

--- a/src/Core/Storage/LocalStorage.php
+++ b/src/Core/Storage/LocalStorage.php
@@ -39,16 +39,16 @@ class LocalStorage implements StorageInterface
     /**
      * @param string $name
      * @param TemporaryFileManager $temporaryFileManager
+     * @param SlugifyInterface $slugify
      * @param Filesystem $localFilesystem
      * @param Filesystem $remoteFilesystem
-     * @param SlugifyInterface $slugify
      */
     public function __construct(
         $name,
         TemporaryFileManager $temporaryFileManager,
+        SlugifyInterface $slugify,
         Filesystem $localFilesystem,
-        Filesystem $remoteFilesystem,
-        SlugifyInterface $slugify
+        Filesystem $remoteFilesystem = null
     ) {
         $this->name = $name;
         $this->temporaryFileManager = $temporaryFileManager;
@@ -121,6 +121,10 @@ class LocalStorage implements StorageInterface
      */
     public function remoteListing()
     {
+        if (!$this->remoteFilesystem) {
+            throw new RemoteStorageNotConfiguredException();
+        }
+        
         return $this->listing($this->remoteFilesystem);
     }
 
@@ -142,6 +146,10 @@ class LocalStorage implements StorageInterface
      */
     public function fetch($file)
     {
+        if (!$this->remoteFilesystem) {
+            throw new RemoteStorageNotConfiguredException();
+        }
+
         $path = sprintf('%s/%s.zip', $this->name, $file);
 
         if (false === ($stream = $this->remoteFilesystem->readStream($path))) {
@@ -156,6 +164,10 @@ class LocalStorage implements StorageInterface
      */
     public function push($file)
     {
+        if (!$this->remoteFilesystem) {
+            throw new RemoteStorageNotConfiguredException();
+        }
+        
         $path = sprintf('%s/%s.zip', $this->name, $file);
 
         if (false === ($stream = $this->localFilesystem->readStream($path))) {

--- a/src/Core/Storage/LocalStorage.php
+++ b/src/Core/Storage/LocalStorage.php
@@ -124,7 +124,7 @@ class LocalStorage implements StorageInterface
         if (!$this->remoteFilesystem) {
             throw new RemoteStorageNotConfiguredException();
         }
-        
+
         return $this->listing($this->remoteFilesystem);
     }
 
@@ -167,7 +167,7 @@ class LocalStorage implements StorageInterface
         if (!$this->remoteFilesystem) {
             throw new RemoteStorageNotConfiguredException();
         }
-        
+
         $path = sprintf('%s/%s.zip', $this->name, $file);
 
         if (false === ($stream = $this->localFilesystem->readStream($path))) {

--- a/src/Core/Storage/RemoteStorageNotConfiguredException.php
+++ b/src/Core/Storage/RemoteStorageNotConfiguredException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Nanbando\Core\Storage;
+
+class RemoteStorageNotConfiguredException extends \Exception
+{
+    public function __construct()
+    {
+        parent::__construct('RemoteStorage was not configured.');
+    }
+}

--- a/tests/Unit/Bundle/Command/CheckCommandTest.php
+++ b/tests/Unit/Bundle/Command/CheckCommandTest.php
@@ -1,0 +1,200 @@
+<?php
+
+namespace Nanbando\Unit\Bundle\Command;
+
+use Nanbando\Bundle\Command\CheckCommand;
+use Nanbando\Core\Plugin\PluginInterface;
+use Nanbando\Core\Plugin\PluginRegistry;
+use Prophecy\Argument;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class CheckCommandTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    /**
+     * @var PluginRegistry
+     */
+    private $plugins;
+
+    protected function setUp()
+    {
+        $this->container = $this->prophesize(ContainerInterface::class);
+        $this->plugins = $this->prophesize(PluginRegistry::class);
+    }
+
+    private function getCommandTester($remote = false, $backup = [])
+    {
+        $this->container->getParameter('nanbando.storage.local_directory')->willReturn('/User/test/nanbando');
+        $this->container->getParameter('nanbando.backup')->willReturn($backup);
+        $this->container->has('filesystem.remote')->willReturn($remote);
+
+        $this->container->get('plugins')->willReturn($this->plugins->reveal());
+
+        $command = new CheckCommand();
+        $command->setContainer($this->container->reveal());
+
+        $application = new Application();
+        $application->add($command);
+
+        $command = $application->find('check');
+
+        return new CommandTester($command);
+    }
+
+    public function testExecute()
+    {
+        $commandTester = $this->getCommandTester();
+        $commandTester->execute([]);
+
+        $this->assertContains('Local directory: /User/test/nanbando', $commandTester->getDisplay());
+        $this->assertContains('No remote storage configuration found.', $commandTester->getDisplay());
+        $this->assertContains('No backup configuration found.', $commandTester->getDisplay());
+    }
+
+    public function testExecuteWithRemote()
+    {
+        $commandTester = $this->getCommandTester(true);
+        $commandTester->execute([]);
+
+        $this->assertContains('Local directory: /User/test/nanbando', $commandTester->getDisplay());
+        $this->assertContains('Remote Storage: YES', $commandTester->getDisplay());
+    }
+
+    public function testExecutePluginNotFound()
+    {
+        $this->plugins->has('my-plugin')->willReturn(false);
+
+        $commandTester = $this->getCommandTester(true, ['test' => ['plugin' => 'my-plugin']]);
+        $commandTester->execute([]);
+
+        $this->assertContains('Plugin "my-plugin" not found', $commandTester->getDisplay());
+    }
+
+    public function testExecutePluginNotFoundMultiple()
+    {
+        $plugin = $this->prophesize(PluginInterface::class);
+        $plugin->configureOptionsResolver(Argument::type(OptionsResolver::class))->shouldBeCalled();
+
+        $this->plugins->has('my-plugin-1')->willReturn(true);
+        $this->plugins->getPlugin('my-plugin-1')->willReturn($plugin->reveal());
+        $this->plugins->has('my-plugin-2')->willReturn(false);
+
+        $commandTester = $this->getCommandTester(
+            true,
+            [
+                'test-1' => ['plugin' => 'my-plugin-1', 'parameter' => []],
+                'test-2' => ['plugin' => 'my-plugin-2'],
+            ]
+        );
+        $commandTester->execute([]);
+
+
+        $this->assertRegExp('/test-1[-\s]*OK/', $commandTester->getDisplay());
+        $this->assertRegExp('/test-2[-\s]*\[WARNING\] Plugin "my-plugin-2" not found/', $commandTester->getDisplay());
+    }
+
+    public function testExecuteParameterNotValid()
+    {
+        $plugin = $this->prophesize(PluginInterface::class);
+        $plugin->configureOptionsResolver(Argument::type(OptionsResolver::class))
+            ->will(
+                function ($args) {
+                    $args[0]->setRequired(['chmod', 'directory']);
+                }
+            );
+
+        $this->plugins->has('my-plugin')->willReturn(true);
+        $this->plugins->getPlugin('my-plugin')->willReturn($plugin->reveal());
+
+        $commandTester = $this->getCommandTester(
+            true,
+            ['test' => ['plugin' => 'my-plugin', 'parameter' => ['directory' => '/test']]]
+        );
+        $commandTester->execute([]);
+
+        $this->assertContains('Parameter not valid', $commandTester->getDisplay());
+    }
+
+    public function testExecuteParameterNotValidMultiple()
+    {
+        $plugin = $this->prophesize(PluginInterface::class);
+        $plugin->configureOptionsResolver(Argument::type(OptionsResolver::class))
+            ->will(
+                function ($args) {
+                    $args[0]->setRequired(['chmod', 'directory']);
+                }
+            );
+
+        $this->plugins->has('my-plugin-1')->willReturn(true);
+        $this->plugins->has('my-plugin-2')->willReturn(true);
+        $this->plugins->getPlugin('my-plugin-1')->willReturn($plugin->reveal());
+        $this->plugins->getPlugin('my-plugin-2')->willReturn($plugin->reveal());
+
+        $commandTester = $this->getCommandTester(
+            true,
+            [
+                'test-1' => ['plugin' => 'my-plugin-1', 'parameter' => ['directory' => '/test']],
+                'test-2' => ['plugin' => 'my-plugin-2', 'parameter' => ['directory' => '/test', 'chmod' => 0777]],
+            ]
+        );
+        $commandTester->execute([]);
+
+        $this->assertRegExp('/test-1[-\s]*\[WARNING\] Parameter not valid/', $commandTester->getDisplay());
+        $this->assertRegExp('/test-2[-\s]*OK/', $commandTester->getDisplay());
+    }
+
+    public function testExecuteOK()
+    {
+        $plugin = $this->prophesize(PluginInterface::class);
+        $plugin->configureOptionsResolver(Argument::type(OptionsResolver::class))
+            ->will(
+                function ($args) {
+                    $args[0]->setRequired(['chmod', 'directory']);
+                }
+            );
+
+        $this->plugins->has('my-plugin')->willReturn(true);
+        $this->plugins->getPlugin('my-plugin')->willReturn($plugin->reveal());
+
+        $commandTester = $this->getCommandTester(
+            true,
+            ['test' => ['plugin' => 'my-plugin', 'parameter' => ['directory' => '/test', 'chmod' => 0777]]]
+        );
+        $commandTester->execute([]);
+
+        $this->assertContains('OK', $commandTester->getDisplay());
+    }
+
+    public function testExecuteOKMultiple()
+    {
+        $plugin = $this->prophesize(PluginInterface::class);
+        $plugin->configureOptionsResolver(Argument::type(OptionsResolver::class))
+            ->will(
+                function ($args) {
+                    $args[0]->setRequired(['chmod', 'directory']);
+                }
+            );
+
+        $this->plugins->has('my-plugin')->willReturn(true);
+        $this->plugins->getPlugin('my-plugin')->willReturn($plugin->reveal());
+
+        $commandTester = $this->getCommandTester(
+            true,
+            [
+                'test-1' => ['plugin' => 'my-plugin', 'parameter' => ['directory' => '/test', 'chmod' => 0777]],
+                'test-2' => ['plugin' => 'my-plugin', 'parameter' => ['directory' => '/test', 'chmod' => 0777]],
+            ]
+        );
+        $commandTester->execute([]);
+
+        $this->assertRegExp('/test-1[-\s]*OK/', $commandTester->getDisplay());
+        $this->assertRegExp('/test-2[-\s]*OK/', $commandTester->getDisplay());
+    }
+}

--- a/tests/Unit/Core/Flysystem/PrefixAdapterTest.php
+++ b/tests/Unit/Core/Flysystem/PrefixAdapterTest.php
@@ -3,8 +3,9 @@
 namespace Nanbando\Tests\Unit\Core\Flysystem;
 
 use League\Flysystem\AdapterInterface;
+use League\Flysystem\Config;
 use Nanbando\Core\Flysystem\PrefixAdapter;
-use Webmozart\PathUtil\Path;
+use Prophecy\Argument;
 
 class PrefixAdapterTest extends \PHPUnit_Framework_TestCase
 {
@@ -25,17 +26,77 @@ class PrefixAdapterTest extends \PHPUnit_Framework_TestCase
         $this->adapter = new PrefixAdapter(__DIR__, $this->decorated->reveal());
     }
 
-    public function testCopy()
+    public function provideDelegateData()
     {
-        $this->decorated->copy(Path::join([__DIR__, 'test.json']), Path::join([__DIR__, 'test-new.json']));
+        $config = new Config();
 
-        $this->adapter->copy('test.json', 'test-new.json');
+        return [
+            ['write', ['/test.json', 'test content', $config], ['/test/test.json', 'test content', $config]],
+            ['writeStream', ['/test.json', 'test content', $config], ['/test/test.json', 'test content', $config]],
+            ['update', ['/test.json', 'test content', $config], ['/test/test.json', 'test content', $config]],
+            ['updateStream', ['/test.json', 'test content', $config], ['/test/test.json', 'test content', $config]],
+            ['rename', ['/test.json', '/test-new.json'], ['/test/test.json', '/test/test-new.json']],
+            ['copy', ['/test.json', '/test-new.json'], ['/test/test.json', '/test/test-new.json']],
+            ['delete', ['/test'], ['/test/test']],
+            ['deleteDir', ['/test'], ['/test/test']],
+            ['createDir', ['/test', $config], ['/test/test', $config]],
+            ['createDir', ['/test', $config], ['/test/test', $config]],
+            ['setVisibility', ['/test.json', true], ['/test/test.json', true]],
+            ['setVisibility', ['/test.json', false], ['/test/test.json', false]],
+            ['has', ['/test.json'], ['/test/test.json'], true],
+            ['has', ['/test.json'], ['/test/test.json'], false],
+            ['read', ['/test.json'], ['/test/test.json'], 'test content'],
+            ['getMetadata', ['/test.json'], ['/test/test.json'], 'test metadata'],
+            ['getSize', ['/test.json'], ['/test/test.json'], 42],
+            ['getMimetype', ['/test.json'], ['/test/test.json'], 'application/test'],
+            ['getTimestamp', ['/test.json'], ['/test/test.json'], new \DateTime()],
+            ['getTimestamp', ['/test.json'], ['/test/test.json'], new \DateTime()],
+            ['getVisibility', ['/test.json'], ['/test/test.json'], true],
+            ['getVisibility', ['/test.json'], ['/test/test.json'], false],
+        ];
     }
 
-    public function testHas()
+    /**
+     * @dataProvider provideDelegateData
+     */
+    public function testDelegate($method, array $parameter, array $delegatedParameter, $result = null, $root = '/test')
     {
-        $this->decorated->has(Path::join([__DIR__, 'test.json']));
+        $adapter = $this->prophesize(AdapterInterface::class);
 
-        $this->adapter->has('test.json');
+        $adapter->{$method}(Argument::cetera())->will(
+            function ($arguments) use ($delegatedParameter, $result) {
+                PrefixAdapterTest::assertEquals($delegatedParameter, $arguments);
+
+                return $result;
+            }
+        );
+
+        $this->assertEquals(
+            $result,
+            call_user_func_array([new PrefixAdapter($root, $adapter->reveal()), $method], $parameter)
+        );
+    }
+
+    public function testListContents()
+    {
+        $adapter = $this->prophesize(AdapterInterface::class);
+        $prefixAdapter = new PrefixAdapter('/test', $adapter->reveal());
+
+        $adapter->listContents('/test/dir', false)->willReturn(
+            [
+                ['path' => 'test/dir/test-1.json', 'dirname' => 'test/dir'],
+                ['path' => 'test/dir/test-2.json', 'dirname' => 'test/dir'],
+            ]
+        );
+
+        $result = $prefixAdapter->listContents('/dir');
+
+        $this->assertEquals(
+            [
+                ['path' => 'dir/test-1.json', 'dirname' => 'dir'],
+                ['path' => 'dir/test-2.json', 'dirname' => 'dir'],
+            ],
+            $result
+        );
     }
 }

--- a/tests/Unit/Core/Storage/LocalStorageTest.php
+++ b/tests/Unit/Core/Storage/LocalStorageTest.php
@@ -7,6 +7,7 @@ use League\Flysystem\Filesystem;
 use League\Flysystem\ZipArchive\ZipArchiveAdapter;
 use Nanbando\Core\Flysystem\ReadonlyAdapter;
 use Nanbando\Core\Storage\LocalStorage;
+use Nanbando\Core\Storage\RemoteStorageNotConfiguredException;
 use Nanbando\Core\Storage\StorageInterface;
 use Nanbando\Core\Temporary\TemporaryFileManager;
 use Prophecy\Argument;
@@ -54,9 +55,9 @@ class LocalStorageTest extends \PHPUnit_Framework_TestCase
         $this->storage = new LocalStorage(
             $this->name,
             $this->temporaryFileManager->reveal(),
+            $this->slugify->reveal(),
             $this->localFilesystem->reveal(),
-            $this->remoteFilesystem->reveal(),
-            $this->slugify->reveal()
+            $this->remoteFilesystem->reveal()
         );
     }
 
@@ -188,5 +189,47 @@ class LocalStorageTest extends \PHPUnit_Framework_TestCase
         $this->remoteFilesystem->putStream($path, Argument::any())->shouldNotBeCalled();
 
         $this->storage->push($file);
+    }
+
+    public function testPushNoRemote()
+    {
+        $this->setExpectedException(RemoteStorageNotConfiguredException::class);
+
+        $storage = new LocalStorage(
+            $this->name,
+            $this->temporaryFileManager->reveal(),
+            $this->slugify->reveal(),
+            $this->localFilesystem->reveal()
+        );
+
+        $storage->push('test');
+    }
+
+    public function testFetchNoRemote()
+    {
+        $this->setExpectedException(RemoteStorageNotConfiguredException::class);
+
+        $storage = new LocalStorage(
+            $this->name,
+            $this->temporaryFileManager->reveal(),
+            $this->slugify->reveal(),
+            $this->localFilesystem->reveal()
+        );
+
+        $storage->fetch('test');
+    }
+
+    public function testRemoteListingNoRemote()
+    {
+        $this->setExpectedException(RemoteStorageNotConfiguredException::class);
+
+        $storage = new LocalStorage(
+            $this->name,
+            $this->temporaryFileManager->reveal(),
+            $this->slugify->reveal(),
+            $this->localFilesystem->reveal()
+        );
+
+        $storage->remoteListing();
     }
 }


### PR DESCRIPTION
This PR make the global configuration optional and adds a `check` command to help finding configuration errors.

This fixes #21 
#### TODO
- [x] add check for backup configuration
  - [x] all plugins installed?
  - [x] maybe find the correct plugin with composer? #23
  - [x] parameters correct?
