### PR TITLE
Added environment to generate filename

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -37,7 +37,6 @@ configuration and later also the dependencies for this backup-project.
 
     {
         "name": "application",
-        "environment": "prod", # [optional] or "stage" or "dev" will be used to generate filename.
         "backup": {
             "data": {
                 "plugin": "directory",
@@ -68,6 +67,11 @@ The second command will create a new backup zip in the local folder
 ``~/nanbando/local/application/<date>_<environment>_<label>.zip``. The environment and the label are optional and will
 be omitted if not exists (e.g. without environment ``<date>_<label>.zip`` or without label and environment
 ``<date>.zip``).
+
+.. note::
+
+    The environment can be set via the config file ``"environment"`` or env-variable ``NANBANDO_ENVIRONMENT``.
+    Example: ``NANBANDO_ENVIRONMENT=prod php nanbando.phar backup``.
 
 After this steps you can do following steps:
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -37,6 +37,7 @@ configuration and later also the dependencies for this backup-project.
 
     {
         "name": "application",
+        "environment": "prod", # [optional] or "stage" or "dev" will be used to generate filename.
         "backup": {
             "data": {
                 "plugin": "directory",
@@ -63,7 +64,10 @@ configuration. If you have added requirements to the configuration the applicati
     php nanbando.phar reconfigure
     php nanbando.phar backup
 
-The second command will create a new backup zip in the local folder ``~/nanbando/local/application/<date>.zip``.
+The second command will create a new backup zip in the local folder
+``~/nanbando/local/application/<date>_<environment>_<label>.zip``. The environment and the label are optional and will
+be omitted if not exists (e.g. without environment ``<date>_<label>.zip`` or without label and environment
+``<date>.zip``).
 
 After this steps you can do following steps:
 

--- a/src/Bundle/Command/CheckCommand.php
+++ b/src/Bundle/Command/CheckCommand.php
@@ -39,6 +39,8 @@ EOT
 
         $io->title('Configuration Check Report');
 
+        $io->writeln('Name:            ' . $this->getContainer()->getParameter('nanbando.name'));
+        $io->writeln('Environment:     ' . $this->getContainer()->getParameter('nanbando.environment'));
         $io->writeln('Local directory: ' . $this->getContainer()->getParameter('nanbando.storage.local_directory'));
 
         if (!$this->getContainer()->has('filesystem.remote')) {

--- a/src/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bundle/DependencyInjection/Configuration.php
@@ -8,6 +8,8 @@ use Webmozart\PathUtil\Path;
 
 class Configuration implements ConfigurationInterface
 {
+    const ENV_ENVIRONMENT = 'NANBANDO_ENVIRONMENT';
+
     /**
      * {@inheritdoc}
      */
@@ -19,7 +21,9 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->scalarNode('name')->defaultValue('nanbando')->end()
-                ->enumNode('environment')->values(['prod', 'dev', 'stage'])->defaultNull()->end()
+                ->scalarNode('environment')
+                    ->defaultValue('%env(' . self::ENV_ENVIRONMENT . ')%')
+                ->end()
                 ->arrayNode('application')
                     ->addDefaultsIfNotSet()
                     ->children()

--- a/src/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bundle/DependencyInjection/Configuration.php
@@ -19,6 +19,7 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->scalarNode('name')->defaultValue('nanbando')->end()
+                ->enumNode('environment')->values(['prod', 'dev', 'stage'])->defaultNull()->end()
                 ->arrayNode('application')
                     ->addDefaultsIfNotSet()
                     ->children()

--- a/src/Bundle/DependencyInjection/NanbandoExtension.php
+++ b/src/Bundle/DependencyInjection/NanbandoExtension.php
@@ -21,6 +21,7 @@ class NanbandoExtension extends Extension
         $config = $this->processConfiguration($configuration, $configs);
 
         $container->setParameter('nanbando.name', $config['name']);
+        $container->setParameter('nanbando.environment', $config['environment']);
         $container->setParameter('nanbando.application.name', $config['application']['name']);
         $container->setParameter('nanbando.application.version', $config['application']['version']);
         $container->setParameter('nanbando.application.options', $config['application']['options']);

--- a/src/Bundle/Resources/config/services.xml
+++ b/src/Bundle/Resources/config/services.xml
@@ -33,6 +33,7 @@
         <!-- storage -->
         <service id="storage" class="Nanbando\Core\Storage\LocalStorage">
             <argument type="string">%nanbando.name%</argument>
+            <argument type="string">%nanbando.environment%</argument>
             <argument type="service" id="temporary_files"/>
             <argument type="service" id="slugify"/>
             <argument type="service" id="filesystem"/>

--- a/src/Bundle/Resources/config/services.xml
+++ b/src/Bundle/Resources/config/services.xml
@@ -2,6 +2,10 @@
 <container xmlns="http://symfony.com/schema/dic/services"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <parameters>
+        <parameter key="env(NANBANDO_ENVIRONMENT)"></parameter>
+    </parameters>
+
     <services>
         <!-- kernel -->
         <service id="event_dispatcher" class="Symfony\Component\EventDispatcher\ContainerAwareEventDispatcher">

--- a/src/Core/Storage/LocalStorage.php
+++ b/src/Core/Storage/LocalStorage.php
@@ -23,6 +23,11 @@ class LocalStorage implements StorageInterface
     private $name;
 
     /**
+     * @var string
+     */
+    private $environment;
+
+    /**
      * @var TemporaryFilesystemInterface
      */
     private $temporaryFileSystem;
@@ -54,6 +59,7 @@ class LocalStorage implements StorageInterface
 
     /**
      * @param string $name
+     * @param $environment
      * @param TemporaryFilesystemInterface $temporaryFileSystem
      * @param SlugifyInterface $slugify
      * @param SymfonyFilesystem $filesystem
@@ -63,6 +69,7 @@ class LocalStorage implements StorageInterface
      */
     public function __construct(
         $name,
+        $environment,
         TemporaryFilesystemInterface $temporaryFileSystem,
         SlugifyInterface $slugify,
         SymfonyFilesystem $filesystem,
@@ -71,6 +78,7 @@ class LocalStorage implements StorageInterface
         Filesystem $remoteFilesystem = null
     ) {
         $this->name = $name;
+        $this->environment = $environment;
         $this->temporaryFileSystem = $temporaryFileSystem;
         $this->slugify = $slugify;
         $this->filesystem = $filesystem;
@@ -116,9 +124,10 @@ class LocalStorage implements StorageInterface
         $adapter->getArchive()->close();
 
         $path = sprintf(
-            '%s/%s%s.zip',
+            '%s/%s%s%s.zip',
             $this->name,
             date(self::FILE_NAME_PATTERN),
+            (!empty($this->environment) ? ('_' . $this->slugify->slugify($this->environment)) : ''),
             (!empty($label) ? ('_' . $this->slugify->slugify($label)) : '')
         );
         $this->localFilesystem->putStream($path, fopen($filename, 'r'));

--- a/tests/Unit/Bundle/Command/CheckCommandTest.php
+++ b/tests/Unit/Bundle/Command/CheckCommandTest.php
@@ -39,6 +39,10 @@ class CheckCommandTest extends \PHPUnit_Framework_TestCase
 
     private function getCommandTester($remote = false, $backup = [])
     {
+        $this->container->hasParameter('nanbando.name')->willReturn(true);
+        $this->container->getParameter('nanbando.name')->willReturn('test');
+        $this->container->hasParameter('nanbando.environment')->willReturn(true);
+        $this->container->getParameter('nanbando.environment')->willReturn('prod');
         $this->container->getParameter('nanbando.storage.local_directory')->willReturn('/User/test/nanbando');
         $this->container->getParameter('nanbando.backup')->willReturn($backup);
         $this->container->hasParameter('nanbando.application.name')->willReturn(true);


### PR DESCRIPTION
This PR extends the configuration with a config value `environment`. This value can be set by config value or environment variable `NANBANDO_ENVIRONMENT` will be used.

Fixes #53 